### PR TITLE
Fixed return value of runtests.py and correct failing cli tests

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -6,7 +6,7 @@ def main():
     loader = unittest.TestLoader()
     suite = loader.discover('tests')
     result = unittest.TextTestRunner(verbosity=2).run(suite)
-    sys.exit(1 if result.errors else 0)
+    sys.exit(not result.wasSuccessful())
 
 
 if __name__ == '__main__':

--- a/tests/test_curl.py
+++ b/tests/test_curl.py
@@ -7,18 +7,18 @@ from tests.utils import server
 class CurlTests(unittest.TestCase):
     def test_cli(self):
         with server():
-            self.assertTrue(cli('127.0.0.1', 'host.name/'))
+            self.assertFalse(cli('127.0.0.1', 'host.name/'))
 
     def test_cli_nok(self):
         with server(status=300):
-            self.assertFalse(cli('127.0.0.1:3030', '--timeout', '10'))
+            self.assertTrue(cli('127.0.0.1:3030', '--timeout', '10'))
 
     def test_file_socket(self):
         fname = '/tmp/unix-socket'
 
         with server(addr=fname, params=(socket.AF_UNIX, socket.SOCK_STREAM)):
-            self.assertTrue(cli(fname))
+            self.assertFalse(cli(fname))
 
     def test_headers(self):
         with server(callback=lambda x: self.assertIn(b'localhost', x)):
-            self.assertTrue(cli('127.0.0.1:3030', '-H', 'Host: localhost'))
+            self.assertFalse(cli('127.0.0.1:3030', '-H', 'Host: localhost'))


### PR DESCRIPTION
- runtests was checking results.error but not result failures.
- updated to use result.wasSuccessful()
- Fix uncovered 4 failing cli tests
-- test assertion were wrong (inverted) cli code was correct