### PR TITLE
Easier to read pack uwsgi vars

### DIFF
--- a/tests/test_uwsgi_structs.py
+++ b/tests/test_uwsgi_structs.py
@@ -1,0 +1,48 @@
+import unittest
+
+from uwsgi_tools import uwsgi_structs as uw
+
+
+class TestUwsgiPacketHeader(unittest.TestCase):
+    header = uw.UwsgiPacketHeader(0, 166, 0)
+    header_bytes = b'\x00\xa6\x00\x00'
+
+    def test_packet_header_serializes(self):
+        expected = self.header_bytes
+
+        self.assertEqual(expected, bytearray(self.header))
+
+    def test_packet_header_deserializes(self):
+        buffer = bytearray(self.header_bytes)
+        expected_header = uw.UwsgiPacketHeader(0, 166, 0)
+
+        header = uw.UwsgiPacketHeader.from_buffer(buffer)
+        self.assertEqual(
+            bytearray(expected_header),
+            bytearray(header)
+        )
+
+
+class TestUwsgiVar(unittest.TestCase):
+    key = b'foo'
+    key_size = len(key)
+    val = b'bar'
+    val_size = len(val)
+    var = uw.UwsgiVar(key_size, key, val_size, val)
+    var_bytes = b'\x03\x00foo\x03\x00bar'
+
+    def test_var_serializes(self):
+        self.assertEqual(
+            self.var_bytes,
+            bytearray(self.var)
+        )
+
+    def test_var_deserializes(self):
+        buffer = bytearray(self.var_bytes)
+        expected = self.var
+
+        var = uw.UwsgiVar.from_buffer(buffer)
+        self.assertEqual(
+            bytearray(expected),
+            bytearray(var)
+        )

--- a/uwsgi_tools/compat.py
+++ b/uwsgi_tools/compat.py
@@ -2,7 +2,7 @@ import sys
 
 __all__ = [
     'BaseHTTPRequestHandler', 'TCPServer', 'get_content_type', 'urlsplit',
-    'hex2bytes',
+    'struct2bytes',
 ]
 
 PY3 = sys.version_info[0] == 3
@@ -25,8 +25,8 @@ def get_content_type(headers):
         return headers.typeheader
 
 
-def hex2bytes(s):
+def struct2bytes(s):
     if PY3:
-        return bytes.fromhex(s)
+        return bytes(s)
     else:
-        return s.decode('hex')
+        return bytes(bytearray(s))

--- a/uwsgi_tools/uwsgi_structs.py
+++ b/uwsgi_tools/uwsgi_structs.py
@@ -1,0 +1,57 @@
+"""
+From definitions available at
+http://uwsgi-docs.readthedocs.io/en/latest/Protocol.html
+"""
+
+import ctypes
+
+
+class UwsgiPacketHeader(ctypes.Structure):
+    """
+    struct uwsgi_packet_header {
+        uint8_t modifier1;
+        uint16_t datasize;
+        uint8_t modifier2;
+    }
+    """
+    _pack_ = 1
+    _fields_ = [
+        ("modifier1", ctypes.c_int8),
+        ("datasize", ctypes.c_int16),
+        ("modifier2", ctypes.c_int8),
+    ]
+
+
+class UwsgiVar(object):
+    """
+    struct uwsgi_var {
+        uint16_t key_size;
+        uint8_t key[key_size];
+        uint16_t val_size;
+        uint8_t val[val_size];
+    }
+    """
+
+    def __new__(self, key_size, key, val_size, val):
+        class UwsgiVar(ctypes.Structure):
+            _pack_ = 1
+            _fields_ = [
+                ("key_size", ctypes.c_int16),
+                ("key", ctypes.c_char * key_size),
+                ("val_size", ctypes.c_int16),
+                ("val", ctypes.c_char * val_size),
+            ]
+
+        return UwsgiVar(key_size, key, val_size, val)
+
+    @classmethod
+    def from_buffer(cls, buffer, offset=0):
+        key_size = ctypes.c_int16.from_buffer(buffer, offset).value
+        offset += ctypes.sizeof(ctypes.c_int16)
+        key = (ctypes.c_char * key_size).from_buffer(buffer, offset).value
+        offset += ctypes.sizeof(ctypes.c_char * key_size)
+        val_size = ctypes.c_int16.from_buffer(buffer, offset).value
+        offset += ctypes.sizeof(ctypes.c_int16)
+        val = (ctypes.c_char * val_size).from_buffer(buffer, offset).value
+
+        return cls(key_size, key, val_size, val)


### PR DESCRIPTION
NOTE: builds on work in #7 

This is some work I did whilst trying to debug another issue. It doesn't change the functionality.
But now we are able to reference uwsgi definitions documented at http://uwsgi-docs.readthedocs.io/en/latest/Protocol.html

From commit 5879abe0d2419d623682f630de3e12cc97f94779:

    Updates pack_uwsgi_vars
    
    Old packing of uwsgi vars seemed a little bit like magic and was hard to understand
    at least for mere mortals like myself.
    
    Created a pair of C Structures using definitions on uwsgi site and a helper function
    to convert to bytes.
