### PR TITLE
Fixes method post

### DIFF
--- a/tests/test_curl.py
+++ b/tests/test_curl.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import socket
 import unittest
 from uwsgi_tools.curl import cli
@@ -22,3 +23,23 @@ class CurlTests(unittest.TestCase):
     def test_headers(self):
         with server(callback=lambda x: self.assertIn(b'localhost', x)):
             self.assertFalse(cli('127.0.0.1:3030', '-H', 'Host: localhost'))
+
+    def test_post(self):
+        requests = []
+
+        def request_sniper(x):
+            requests.append(deepcopy(x))
+
+        with server(callback=request_sniper):
+            self.assertFalse(cli(
+                '--method', 'POST',
+                '--header', 'Content-Type: application/json',
+                r'''--data=\'{"foo":"bar"}\'''',
+                '127.0.0.1',
+                'host.name/'))
+
+        self.assertIn(b'POST', requests[0])
+        # Magic number is the val_size + val
+        self.assertIn(b'CONTENT_LENGTH\x02\x0017', requests[0])
+        self.assertIn(b'CONTENT_TYPE', requests[0])
+        self.assertIn(b'application/json', requests[0])

--- a/uwsgi_tools/proxy.py
+++ b/uwsgi_tools/proxy.py
@@ -41,7 +41,7 @@ class RequestHandler(WSGIRequestHandler):
         env.pop('HTTP_REFERER', 0)
 
         cl = env['CONTENT_LENGTH']
-        body = repr(self.rfile.read(int(cl))) if cl else ''
+        body = (repr(self.rfile.read(int(cl))) if cl else '').encode('utf-8')
 
         resp = ask_uwsgi((self.server.uwsgi_addr, self.server.uwsgi_port),
                          var=env, body=body)


### PR DESCRIPTION
Adds CONTENT_LENGTH & CONTENT_TYPE so that post requests work correctly

Many frameworks/applications will rely on CONTENT_LENGTH to determine the length of the body appended to the end of uwsgi_packet_header + uwsgi_vars.
 